### PR TITLE
Build ContainerSSH guest image

### DIFF
--- a/packer/files/Dockerfile
+++ b/packer/files/Dockerfile
@@ -1,0 +1,22 @@
+# modified from https://github.com/ContainerSSH/guest-image/blob/main/Dockerfile
+FROM containerssh/agent:latest AS agent
+
+FROM ubuntu:22.04
+
+RUN echo "\e[1;32mUpdating packages and installing SFTP server package...\e[0m" && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -fuy --allow-downgrades --allow-remove-essential --allow-change-held-packages upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -fuy --allow-downgrades --allow-remove-essential --allow-change-held-packages dist-upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -fuy --allow-downgrades --allow-remove-essential --allow-change-held-packages install ssh && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -y autoremove && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -y clean
+
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
+USER ubuntu
+WORKDIR /home/ubuntu
+
+COPY --from=agent /usr/bin/containerssh-agent /usr/bin/containerssh-agent
+
+CMD ["/bin/bash"]
+SHELL ["/bin/bash"]
+ONBUILD RUN echo "The ContainerSSH guest image is not intended as a base image and may change at any time. Please build your own image." >&2 && exit 1

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -45,7 +45,10 @@ build {
   }
 
   provisioner "shell" {
-    script = "./scripts/install_docker.sh"
+    scripts = [
+      "./scripts/install_docker.sh",
+      "./scripts/build_containerssh_guest_image.sh"
+    ]
   }
 
   provisioner "shell" {

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -50,12 +50,6 @@ build {
       "./scripts/build_containerssh_guest_image.sh"
     ]
   }
-
-  provisioner "shell" {
-    inline = [
-      "docker pull containerssh/containerssh-guest-image:latest"
-    ]
-  }
 }
 
 build {
@@ -82,16 +76,15 @@ build {
     destination = "/home/deployer/"
   }
 
-  provisioner "file" {
-    source      = "./files/config.yaml"
-    destination = "/srv/containerssh/config.yaml"
+  provisioner "shell" {
+    script            = "./scripts/update_apt_packages.sh"
+    expect_disconnect = true
   }
 
   provisioner "shell" {
-    script = "./scripts/containerssh_config.sh"
-  }
-
-  provisioner "shell" {
-    script = "./scripts/install_docker.sh"
+    scripts = [
+      "./scripts/containerssh_config.sh",
+      "./scripts/install_docker.sh"
+    ]
   }
 }

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -24,23 +24,24 @@ build {
 
   provisioner "shell" {
     inline = [
-      "mkdir -p /home/deployer/tmp",
-      "mkdir /etc/docker/",
-      "mkdir /var/docker/"
+      "mkdir -p /home/deployer/files",
+      "mkdir -p /home/deployer/scripts"
     ]
   }
 
   provisioner "file" {
-    source      = "./scripts/apt_get_wait_lock.sh"
-    destination = "/home/deployer/tmp/apt_get_wait_lock.sh"
+    source      = "./scripts"
+    destination = "/home/deployer/"
   }
+
+  provisioner "file" {
+    source      = "./files"
+    destination = "/home/deployer/"
+  }
+
   provisioner "shell" {
     script            = "./scripts/update_apt_packages.sh"
     expect_disconnect = true
-  }
-  provisioner "file" {
-    source      = "./scripts/apt_get_wait_lock.sh"
-    destination = "/home/deployer/tmp/apt_get_wait_lock.sh"
   }
 
   provisioner "shell" {
@@ -62,29 +63,20 @@ build {
 
   provisioner "shell" {
     inline = [
-      "mkdir -p /home/deployer/tmp",
+      "mkdir -p /home/deployer/files",
+      "mkdir -p /home/deployer/scripts",
+      "mkdir -p /srv/containerssh/"
     ]
   }
 
   provisioner "file" {
-    source      = "./scripts/apt_get_wait_lock.sh"
-    destination = "/home/deployer/tmp/apt_get_wait_lock.sh"
-  }
-
-  provisioner "shell" {
-    script            = "./scripts/update_apt_packages.sh"
-    expect_disconnect = true
+    source      = "./scripts"
+    destination = "/home/deployer/"
   }
 
   provisioner "file" {
-    source      = "./scripts/apt_get_wait_lock.sh"
-    destination = "/home/deployer/tmp/apt_get_wait_lock.sh"
-  }
-
-  provisioner "shell" {
-    inline = [
-      "mkdir /srv/containerssh/"
-    ]
+    source      = "./files"
+    destination = "/home/deployer/"
   }
 
   provisioner "file" {

--- a/packer/scripts/build_containerssh_guest_image.sh
+++ b/packer/scripts/build_containerssh_guest_image.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+cd /home/deployer/files
+docker build -t containerssh-guest-image:latest .

--- a/packer/scripts/install_docker.sh
+++ b/packer/scripts/install_docker.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-source /home/deployer/tmp/apt_get_wait_lock.sh
+source /home/deployer/scripts/apt_get_wait_lock.sh
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/packer/scripts/update_apt_packages.sh
+++ b/packer/scripts/update_apt_packages.sh
@@ -4,7 +4,7 @@
 
 set -euxo pipefail
 
-source /home/deployer/tmp/apt_get_wait_lock.sh
+source /home/deployer/scripts/apt_get_wait_lock.sh
 
 export DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Description

This PR will
- close #21 (build a `containerssh-guest-image` image on sacrificial VM.)

## Testing the PR
1. build packer
2. deploy terraform
3. log into sacrificial VM
4. run
   ```bash
   sudo docker image ls
   ```
   You should see `containerssh-guest-image`.

## Takeaways
- For simplicity, we directly build the image on sacrificial VM instead of exporting & importing.
