### PR TITLE
fix: gcloud failed with different default zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Utilities:
    ```bash
    ssh -oHostKeyAlgorithms=+ssh-rsa \
      $(gcloud compute instances describe gateway-vm \
-     --format='get(networkInterfaces[0].accessConfigs[0].natIP)') \
-     -p 2222
+     --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
+     --zone=europe-west3-c) -p 2222
    ```
    Your will be redirected to a newly created container in the sacrificial VM.
 
@@ -57,8 +57,9 @@ To access the log:
 
    - Get the logger VM IP via
      ```bash
-     gcloud compute instances describe logger-vm \
-     --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+     gcloud compute instances describe gateway-vm \
+       --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
+       --zone=europe-west3-c
      ```
 
 1. Log in with credentials generated at `./terraform/credentials.txt`
@@ -85,8 +86,9 @@ We use Grafana for visualizing the collected metrics.
 To get logger-vm IP address:
 
 ```bash
-gcloud compute instances describe logger-vm \
-  --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+gcloud compute instances describe gateway-vm \
+  --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
+  --zone=europe-west3-c
 ```
 
 ## Troubleshooting

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -63,8 +63,8 @@ When complete, access the honeypot via
 ```bash
 ssh -oHostKeyAlgorithms=+ssh-rsa \
   $(gcloud compute instances describe gateway-vm \
-  --format='get(networkInterfaces[0].accessConfigs[0].natIP)') \
-  -p 2222
+  --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
+  --zone=europe-west3-c) -p 2222
 ```
 
 You should be able to log in with any password.

--- a/terraform/scripts/move_certs_to_gateway_vm.sh
+++ b/terraform/scripts/move_certs_to_gateway_vm.sh
@@ -6,10 +6,14 @@ export DEBIAN_FRONTEND=noninteractive
 mkdir -p /tmp/ca
 
 # download key files from sacrificial VM
-gcloud compute scp --recurse deployer@sacrificial-vm:~/{ca,cert,key}.pem /tmp/ca/
+gcloud compute scp \
+   --recurse deployer@sacrificial-vm:~/{ca,cert,key}.pem /tmp/ca/ \
+   --zone=europe-west3-c
 
 # upload key files to gateway VM
-gcloud compute scp --recurse /tmp/ca deployer@gateway-vm:~/.docker
+gcloud compute scp \
+   --recurse /tmp/ca deployer@gateway-vm:~/.docker \
+   --zone=europe-west3-c
 
 # clean up temp files
 rm -rfv /tmp/ca


### PR DESCRIPTION
This PR is based on #30 
**Before merge:** 
- [x] Change merge target to `main`
## Description
This PR will
- fix #33 

## Testing the PR
1. Set zone to a different one
```
gcloud config set compute/zone europe-west2-a
```
2. Run `terraform apply`.
3. It should work without error

You can change the zone back with
```
gcloud config set compute/zone europe-west3-c
```

