### PR TITLE
Remap ssh ports on gateway vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To access the log:
 
    - Get the logger VM IP via
      ```bash
-     gcloud compute instances describe gateway-vm \
+     gcloud compute instances describe logger-vm \
        --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
        --zone=europe-west3-c
      ```
@@ -86,7 +86,7 @@ We use Grafana for visualizing the collected metrics.
 To get logger-vm IP address:
 
 ```bash
-gcloud compute instances describe gateway-vm \
+gcloud compute instances describe logger-vm \
   --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
   --zone=europe-west3-c
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Sacrificial VM provides infrastructure for containers.
 
 ### Ports
 
+SSH:
+- Gateway VM SSH Honeypot: `2222`, `22`
+- Gateway VM SSHD: `2333`
+- Other VMs SSHD: `22`
+
 Audit:
 
 - MinIO server: `9000`
@@ -44,7 +49,7 @@ Utilities:
    ssh -oHostKeyAlgorithms=+ssh-rsa \
      $(gcloud compute instances describe gateway-vm \
      --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
-     --zone=europe-west3-c) -p 2222
+     --zone=europe-west3-c)
    ```
    Your will be redirected to a newly created container in the sacrificial VM.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -76,8 +76,11 @@ You should be able to log in with any password.
 #### SSH to a GCP VM
 
 ```bash
-# ssh to a vm (e.g., gateway-vm, logger-vm, sacrificial-vm)
-gcp compute ssh <vm-name>
+# Gateway VM
+gcloud compute ssh gateway-vm --zone=europe-west3-c --ssh-flag="-p 2333"
+
+# Other VM
+gcp compute ssh <vm-name> --zone=europe-west3-c
 ```
 
 #### Managing MinIO with MinIO Client `mc`

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -64,7 +64,7 @@ When complete, access the honeypot via
 ssh -oHostKeyAlgorithms=+ssh-rsa \
   $(gcloud compute instances describe gateway-vm \
   --format='get(networkInterfaces[0].accessConfigs[0].natIP)' \
-  --zone=europe-west3-c) -p 2222
+  --zone=europe-west3-c)
 ```
 
 You should be able to log in with any password.

--- a/terraform/generate_credentials.sh
+++ b/terraform/generate_credentials.sh
@@ -17,7 +17,7 @@ fi
 
 # exit if file already exists
 if [[ -f "$TARGET_FILE" && $force_write -eq 0 ]]; then
-   echo "Skipped!. File '$TARGET_FILE' already exists."
+   echo "Skipped! File '$TARGET_FILE' already exists."
    echo "To overwrite the file, use '--force' or '-f'."
    exit 0
 fi

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -268,7 +268,8 @@ resource "null_resource" "set_up_docker_tls_and_containerssh" {
     }
 
     scripts = [
-      "./scripts/set_up_and_run_containerssh.sh"
+      "./scripts/set_up_and_run_containerssh.sh",
+      "./scripts/remap_ssh_ports.sh"
     ]
   }
 }

--- a/terraform/scripts/remap_ssh_ports.sh
+++ b/terraform/scripts/remap_ssh_ports.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# redirect 22 to 2222 for ContainerSSH
+sudo iptables -t nat -I PREROUTING -p tcp --dport 22 -j REDIRECT --to-port 2222
+
+# Change SSHD port to 2333
+echo "Port 2333" | sudo tee -a /etc/ssh/sshd_config
+
+nohup bash -c "sleep 5 && sudo systemctl restart ssh" &
+
+sleep 1


### PR DESCRIPTION
**Before merge:** 
- [x] Change merge target to `main`

## Description
> What changes will the PR bring? Refer to relevant issues if applicable
> 
This PR will
- close #31

For Gateway VM:
- `22` and `2222` both redirects to ContainerSSH honeypot
- SSHD port is changed to `2333`.
To SSH into Gateway VM:
```bash
# Before
gcloud compute ssh gateway-vm --zone=europe-west3-c
# After
gcloud compute ssh gateway-vm --zone=europe-west3-c --ssh-flag="-p 2333"
```
## Testing the PR
> How do your team test if the PR is valid?
1. `terraform apply`
2. You should be able to SSH int ContainerSSH via port `22` (default ssh port)
   ```bash
   ssh -oHostKeyAlgorithms=+ssh-rsa \
     $(gcloud compute instances describe gateway-vm \
     --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
   ```
   Note: Port `2222` still works! We just make port `22` redirects to `2222`.
3. You should be able to SSH into the Gateway VM via port `2333`
   ```bash
   gcloud compute ssh gateway-vm --zone=europe-west3-c --ssh-flag="-p 2333"
   ```