### PR TITLE
Configure firewall rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,28 @@ Sacrificial VM provides infrastructure for containers.
 
 ### Ports
 
-SSH:
-- Gateway VM SSH Honeypot: `2222`, `22`
-- Gateway VM SSHD: `2333`
-- Other VMs SSHD: `22`
+Gateway VM:
+- Honeypot gateway: `22`, `2222` (`2222` is redirected to `22`)
+- SSH: `2333`
+- cAdvisor: `8088`
+- Node Exporter: `9100`
+- ContainerSSH auth-config server: `8080`
+- ContainerSSH metrics server(TBD): `9101`
 
-Audit:
-
+Logger VM:
+- SSH: `22`
+- cAdvisor: `8088`
+- Node Exporter: `9100`
 - MinIO server: `9000`
 - MinIO Console: `9090`
-
-Monitoring
-
 - Grafana: `3000`
 - Prometheus: `9091`
 
-Services:
-
-- Auth-Config: `8080`
-- containerSSH Audit-logs: `9101`
-
-Utilities:
-
+Sacrificial VM:
+- SSH: `22`
 - cAdvisor: `8088`
-- Node exporter: `9100`
+- Node Exporter: `9100`
+- Dockerd over TLS: `2376`
 
 ## Setting up the service on GCP
 

--- a/diagrams/infra.drawio.svg
+++ b/diagrams/infra.drawio.svg
@@ -1,11 +1,11 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="794px" height="572px" viewBox="-0.5 -0.5 794 572" content="&lt;mxfile&gt;&lt;diagram id=&quot;bqHKAOC9Ar30NO44-LJo&quot; name=&quot;Page-1&quot;&gt;7V1td6M2Fv41Prv7IRwhAYaPeZ3p7sxOTrPbdvolB2PZpsHICzhx+utXAgkQkrEdIKZtPOek5iKEuC/PfdHFnaDr9e5T4m9WX8kcRxMI5rsJuplAaE6RRf/DKK+cYiKvoCyTcF7QQEV4CH/HfKCgbsM5TjmtIGWERFm4kYkBiWMcZBLNTxLyIg9bkGguETb+EiuEh8CPVOrP4TxbFVTXBhX9Mw6XK3FnE/Aza18M5oR05c/JS42EbifoOiEkK76td9c4YtyT+XK352y5sATH2VEX2MUVz3605Q/3yc/wi/9KiQ/bWYyzCXQiOtfVLKHfluybCYz8H50WclGm2atgTkK28Ryz+U069mUVZvhh4wfs7AvVB0pbZeuIn5776aoc+4yTLKRcvozCZUxpGWGjFyTOHvj0bJTPzwb0EXHCBoRRdE0ikuT3R3Mbu3OL0tMsIU+4dsaFM+Q49IzKJc44tgK8q5E41z5hssZZwpgiztqwuEToMOKcfKkUwhJiX9WUwbL5QJ8r4bKcu5IT/cJFpRcbVKQmpDQPn4WYBCkUhEqyP30VJ+mdwr0XCEK68WNJyM7/tkxDc9lcvPCnu6RDYpKs/ai4lI9pTlbpUW0NxR0UsrISStM8YdtD9/oMXPMZDnVeehezOc5SlpGfMiUD7PEF0OQHTzgLVnxUD8YAzYYxeKZiDNDVGINpe92NwXT2WsNMsPszifHrhsryAKqZJaqVQpv1I7IBkG7hBjgIdEg3c23LBv0I13amh4Ur0LAuXGSik4X73xQn32a/MacNQeTPcFRceuWnlHkQEGbDqyxjjv6STQLvqJPP/DDGSZqujJBQCg8P4N2qlPpdsZIojJ+KCd8+h1A7u8Y1rpE13aDMzQ4rRR+255qyeABSxIMcSyMecLJ06GFNQHus8YBvAkKrK3Tl+q2g7ReyXDJ6zV2pzmNYoDdHBvQzkmVkfQjr6/CugEgfOgc8SeeQFu+RBu/dHvB+9c8Fjv7zr6fbu3//+OvS//Y6vf3pwgMKo/GcBu38kCTZiixJ7Ee3FfVKFkXJNsbD6oIvhIFzPuI3nGWvPB3xtxmRZUX5mbz+wq43bHH4nU+XH9zspKNXfpTD3JUfPC3z9dRg/Ma+dW8sIe3ivl6bCFOyTQKRpHDYzvxkibMW1tncfzJ+tUo/wZGfhc9yEqSTZH7pZZLksaYYsCFhnKW1me8ZoVIqC7mSUlkeamhFMWOlI+XSjgsTpscEzfcJm3OFt4VzOBh1ngBnA4fX6NID3gB4dQChmkDUzMZ87C60MYoTuHi2UKywB3hCU1vWJOGTavBk6nIzp0Wnu6ETPD867cLsl9r37xVQ0aMKmtjB0MjkqchkWaMAIejJns3moHR35HiLH/cGWt4xoPU1jH/4doYUWQ9CoMyOO6X6Qy3Pe0vyrn2SPxdqUtyUVd9UK1qOJqazeqhnaUHTdc4PmuMK6cpidw04RVjTH3B283TWMYB10KRnJe8ugoJ5zK6T5ezvkFUV6NoARJB/MeE/tCFR+ppmeP03CveAPVwYpIctv82mGYu/FDWJupIoGVYzaVuH83mhnDgNf/dn+XxMTbg3opPbVxP7RtWKOkxAVUVazUax/HI/hK9gUt9y0CHCBTCQBWRUuODLOM0NV35TDCGLRcqqcA11O807liB3lLIxZu73H2nOdaZl3manVaeYzPEj3m0ojuThvVCZYl7Feb39Rp3yAnDiTd6tHD92ftDYwAQDFPa7RQKLxQLqa7xzZ+bYjooZsgccovyDGiVHBKZKpCAKPR0rjkc6HVPh+hkjBTiKUAFqQgVvHDkWkjcUxM7Q3hyrMR65015zLL1K7d9UGjZoUdIffzsP890QskwPwJCMWGePXo4MWLx9AHRywAIM4NpyFdHsFq6ISEgGvIvGxlY/wcyBjZNCrNdip+rh4fN4k1NFqfrPVl1kuLKooaMmrCacGqIaKLsiY7C0FZ3dGQ3kU5Cj+hShtef2KZZsoXBqtvuU9vGdfQpS3cdnKg+WNzR0Q8BtDs33JA2zkEg7fZIy+OmmaGhbhDumLoebQmQjjUmMdfZJtllEUeW6bJjjPSMbtsr1bska+YwgpEn0zoj8DZ36sS9DdmRBWEAx4ik0gCac7KNaj47aFCqBtiy4kjjMSNIKwLNDoHxUYdZfMyHm5CjfDr94XpdkkbggICUu3auX7TqXGyNObp9x4f/NSaO/qOx1AbKGanUxaii+EojstQy9wh/qmgHAdN0bjXqv08DHRn7VJglTbGxwsmCJZBzgx7WQeGeFt0xoOHJRxQHqBpWt2Z8SqNJF462TCnSKEvMiSlDys4pfEXCACy7VkPaBMo511LaXTI4xmTY11UIYu1FN9vTfHWPLFZX4PMTVOa6LSkRTXqCm5fTTVPW+NLYZixV+2oSN2ExrnE2t9l9Sy6Che+7HfwjYelgkX3yTR8221ENljy9htnokeY9P2lPBwDSN5p6sq+K8pWuX7aFmYOlyuYYqsUhp86ZY962h7cnZje2ZhsxEaKu9XhBo9mjKfvNObNwLHIrdlh7owQ+ScBEGIduOO9B2rAOAln4v3q9p7vF8Dfn20F57oGvW2ld3VwX6LuIS23k1eVW9jN0SQpmZp5tMJ+aJs8jwPBu5lmMWf+U40gL0dO0jdkXquSEdU5/A1uSJjmWYTv3Tg1xUO/ozyQW6xtQBU8djZWH2VxKLTUN5gKqPOR6xqG/CaOKieqPwcQ1iBWm5xWl2Ea7lMKjHGs0YRJ/bXCk2+lf2Vg5kp6uPrSnXnEf22jrO9KjWm1M3F02w2akRcnA5fw7TKqHcEyL30AGzr7lGmyIerjGfmNkO8QDo0gWsEth51e9dJD15o+50i0RTwzZB7SNbpCnexKwXW8ogs+/MU18tBUNY2ccW/scW/l9pC/9tYZpdD5BlYJhahuqdh9rTt1RP+zNJntgIpiz3CVkmOE0VsfB3rAbazGTbKimvvCjC4/WiuqQFqaYMtiqp7i8ai1K41MyukYzpDgXZtiKJczWzVw3s32tn9M3sI+vl1LJWWMKYGzzVPKlMiuRWS42OnLN78ihJqqJrNYFeeiwdD/XUpSAjxSBdCq1q+5EqfaRK40iVTt+G9uT6IQJnT4288zeSvKefzY/ucRJS7jGpvrvzFe/B1p0vGpfzFUtsB9pPib/wY/+U+uResOvr3dRGi8LHe1e1qilqbOtZntpP7bgq8vSxN6pVMwee4s/7/XUgQaBgtLqgwdQiXNZEv3+nceTeue2ZGw66tZVnpA76PA2f0NVUKfa2fFpD5cPT8/vpyucCgCSvazjUh43c8041P1UxsrR3elKj4EedWovtH3Xqv3id+nTUb1Q/Lc2vW73rq2biZiMB+/JYYL03eqx3x4/17kc56+wB80c5q9tbFUDpuEUqdL73Zv+I3tNtIGdZqhrBLtD0XXaB3vSelQ0bv3fEO0r2vWeljLf6/VE3vZrB86uZKJxOjv+1rT+Caop2nTGqJmqqGmxXzfbxA6mm+nvp5wsfR6FmEKoaJXpxB48H6WH1W/uFjKv/ZQG6/T8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="794px" height="590px" viewBox="-0.5 -0.5 794 590" content="&lt;mxfile&gt;&lt;diagram id=&quot;bqHKAOC9Ar30NO44-LJo&quot; name=&quot;Page-1&quot;&gt;7V1bk6O4Ff41riQPTQkEGB77OrPJTKZrvdnN5KULg2yzjZEDuNu9vz4SSICQbIOBtjfT7qopI8TtnO9856KDZwJv17tPibdZfcUBiiYGCHYTeDcxDMcF5F868FYMuKZbDCyTMCiGQDUwC/9AxaDOR7dhgFI2VgxlGEdZuBEHfRzHyM+EMS9J8Ks4bYGjQBjYeEskDcx8L5JHfwuDbMUeywLV+GcULlf8yjpge9Yen8wG0pUX4NfaELyfwNsE46z4tt7doojKTpTLw5695Y0lKM5aHWAVR7x40ZY93CcvQ6/eGxmcbecxyiaGHZFz3cwT8m1Jv+lAy//IaQ2TPUf2xoWT4G0cIHp+ncx9XYUZmm08n+59JWggY6tsHbHdgZeuyrkvKMlCIuXrKFzGZCzDdPYCx9mMnZ7O8thenzwiSuiEMIpucYST/PowsJATmGQ8zRL8jGp7HGMObZvskaXEBEfvAO1qQ0xqnxBeoyyhQuF7LaM4hEFYN+1i+7UChMnVvqqBwTSZyDwGwmV57kpP5AtTlVpthqQ1rqUgfOFq4kMhH6g0++tXvpNcKdx7AB9IN14sKNn+75YiNNfN1St7umsyJcbJ2ouKQ9mc5skqHNXuobiCNCzdCRlTPOGhhx70GRjyKQ/1vvU+ZtPOUpaRl1KQAfr4nGjyjWeU+Ss2awBjMHTRGAxgSMZgOApj0E2nvzHo9l5rmHNxf8YxetsQXR5hNb1ktVJp82FUNgLTLRwf+b6K6eaOZVpgGOVa9lRkuqkjK5ezYV25UIedlfuvFCXf5r9Tp22AyJujqDj0xkuJ8AyAqQ2vsow6+mt6EuOBOPnMC2OUpOlKCzEZYeGB8bAqtf5Q3EkUxs/FCU8/B4edVZMaQ2QNG0S42XFQDGF7ji6qB0BJPdA2FeoBnbVDNmsK2mONR3wT4Kiu2JXhW2LbL3i5pOM1dyU7j3GJXr8wop/jLMPrY1xfp3eJRIbAHHAFzEFXV/A9VPC94/bn+9XfFyj65R/P9w///Pk/S+/b2/T+1yueUtQEjQIStLNNnGQrvMSxF91XozeiKkqxURlWB3zBlJzzGb+jLHtj6Yi3zbCoKyLP5O3f9HjN4pvf2enyjbudsPXGtnKau/H852V+PzUav7PunTuTa7u4rkuP34VZ7UJk6zu/B/K9ugzd4FfZq/YUbxOfJzaM6jMvWaLsgLgt5nOpjA8iJkGRl4UvYuKk0n5+6HWS5PEpn7DBYZyltTM/0oEKiKZhCUC0GDAfTptPvhR3UOGwfJR2oci0TWD+mNBzrtA2bRHWduDL4ShRPjW8doE7Ahse4b8mzTVzPQ85C2UEZPsOmi8kGx+A/OBUxJDJPV6N/HRV5mcfQH8/7jPOz32Mkfj37wI7qRmpO++14zBX5jCec5+ZrgxX9JsWdA7SVXO+6Q5MV24buvoaxj99O0MCriYhUObevQoJo3HkKaUB5ZP8f7Em4U0R+rzyWGNNWxExmtZIpOnY5yfNdwsYWxFnWUqvEScPaIYjzn6ezmxDWEdNel7K7sovhEftOlnO/2rQmgW5N2BAg33Rjb8pU8T0Lc3Q+i+E7gF9uNBPj1v+IZumIv5SVDzqIJHyt2ZKuA6DoAAnSsM/vHl+PgoT5o3Iya2biXUno6JOE4YMkYNmI1l+udrC7mBSX9BQMcIV0KAJRFa4YrfRzQ1XfpNPwYtFSmt8Dbh1844lybUCGxXmfv+R5lKnKHM3OyWcYhygJ7TbEB7JY3sOmeK8kvM6/UK96iSg40Xerdh/6fIgsYEORlg26BcJLBYLQ11BDuy5bdkyZ4gecIziEmwUNCGYSpECLyP1rGe2dDq6JPUzRgrGRYQKhiJUcC8jx4LicgVfd9qbYzXmQ2c6aI6lhtT+JatxgxYp/fG2QZivteBleoSGRMY6e/TSMmBx9xFQ54AFaMCxHAEser9whUdCIuFdNZbNhglm5GWZW77oNZt9JnuWvDtgn+ceIEOWkm94XSH/FNiNnghLAB4+M3ag5oiwMngnUb2kaEw1XnkUE2RttBQZnt3xjeS/oC37L24h5/ZfpsgGxlQ/7L8Oz+/tv6Dsqj4TfdAcpYENTu25G3jEaZiFWFizFMDgpZuiNW8R7ihcjre3iEYa4xip7BNvs4iQ2m3Z+se6Xzb0Lte7JW1I1PyQJOw7LfI25NRPQxmyLSrClI14amhAEboOsTJgdiqNzJsDLH31SwOruBsCGzjgWqbzWYYT2il5OFkVW2haJTUia6gUSi9UIwPy90DFckPUG4So2sdQIvF7eYCcEJHPpNauA2p43ItsNWAlbDY9U8FautHwVErzaELYe01NjQRNOav95NP7oTFU8U2cNd8Se82eXsNs9YTz3o10oFRN17Xmapgjo95UtUEOkK2Zqii6ASXqNzYnef5THX3nuNJydU0UomHJPTwGUFTHyz7iXmLcSxyS3Zbx2czzk3AR+iEN8460k6oI4EAfD+vDE3osw71UMUDb5JFuSHNfxVNWaFnFdFuqj/e99+oFllu4FcR/hwufDQjy17SLrmOJbaTgH07tTuH/GDUxEULdiUKNql5AKiOKJr3qcu+lbrqaIi/Q9bHqYdNWq8Zd6+I62Oxk0PjXwUuY4mMF8THQeaiCfSpQ39m8HEATyzObV1/P26LG3N2y4FSzdFD7NMwMmnLsrqvMjKdHwyffYAwr+1h9+lh9+pFWn07wuQ7xuW7tIxLD1NTkxpWxlqMsVTupMsHploqoZLRXIKbdyE54taIeg+iKFM8aILi1ZBasXshoGnn1Fke/NOEYbC36N5GKEMVH6dnyTwlQhZ7q+ii0LuujJm9XIW44hLjlXOKHFTc/AogEIJc3RlOGXN740ZVhiMow3k8Zppz0/IaTZzqD+u3HBC8TlMrCZ++BjbQkShdMUlZFlITPap91DfKhmpItWQn9X4YGcgFEVxW+9QFe/1RHz5akiXO1xHd5SefCOkKVouWWcMltorIbK/lRbNhUYOScPZitNCmr7qAJDNKpabtwoF4HkSlG6XU4CNuPqtVH1eoyqlbdF5hdcYUZgrNXqRQxqgIvnxJv4cXeKZWVEV7SgeCkUsgP8JIOlFYiLUWIbTsywIZYzlV7sen5A7kqKAMACmGZZsPpkdAs33pESUjkQYng3eO1qeKd7guL16atXpv+qHV/1Lo/at1DxhONtN1U/HTMu75pwS92IWRfbnOudy+e653L53rnIw/7yMP+3HmYDaS2RyhT53s3DFzQa2oN5ixrmRdQvpy+S/nypNZ/i/cNlv7YqqPi+HwTNlA0wqtrjnF+mPHK+qT9j838GaDJW34uEZqwCTXjMDQPzx8JmnIn8y9fZueHaxlSXgT0DENGGe8hfv8Y0Tol5G/xGyr6EeEqn/eo7CxVfO2ewyDhVHzty9aP/JSU1WzicSZDGqR9yu8vXpQeD9S3z6/cbj9r2JjfW7mWnLNdB2va+NBQuUCV+VOi5P4FFUugOZfWf4ZaeMeqhgVlG0PUePdKWovt+3JWI9OwdPo3kV+8Wqe+h7Ti13+eiqM1j0rjycdxioko1OmEApT7C/GmuNJjQ7np0FJ1unRPLshm9d8NFNio/s8GeP8/&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="126" y="32" width="400" height="455" rx="60" ry="60" fill="#d5e8d4" stroke="#82b366" stroke-dasharray="3 3" pointer-events="all"/>
+        <rect x="126" y="43" width="400" height="444" rx="60" ry="60" fill="#d5e8d4" stroke="#82b366" stroke-dasharray="3 3" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 398px; height: 1px; padding-top: 39px; margin-left: 127px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 398px; height: 1px; padding-top: 50px; margin-left: 127px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 Gateway Subnet
@@ -15,18 +15,18 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="326" y="51" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                <text x="326" y="62" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
                     Gateway Subnet...
                 </text>
             </switch>
         </g>
-        <rect x="186" y="88" width="280" height="159" rx="23.85" ry="23.85" fill="none" stroke="none" pointer-events="all"/>
-        <path d="M 207.86 89.55 L 442.98 89.44 L 454.76 89.45 L 460.86 95.95 L 465.86 111.57 L 465.78 223.74 L 461.66 239.62 L 458.95 239.9 L 451.78 245.33 L 444.15 246.53 L 211.83 248.96 L 193.67 244.85 L 190.31 238.16 L 184.3 224.16 L 186.02 107.29 L 188.45 97.95 L 196.9 92.16 L 208.85 88.27" fill="rgb(255, 255, 255)" stroke="none" pointer-events="all"/>
-        <path d="M 209.85 88 M 209.85 88 C 282.7 89.64 354.79 90.4 442.15 88 M 209.85 88 C 292 90.21 373.39 89.44 442.15 88 M 442.15 88 C 458.41 87.63 466.34 96.7 466 111.85 M 442.15 88 C 457.26 86.83 467.83 94.27 466 111.85 M 466 111.85 C 465.14 141.53 465.16 169.45 466 223.15 M 466 111.85 C 466.17 139.26 465.84 164.1 466 223.15 M 466 223.15 C 466.2 240.85 456.63 246.94 442.15 247 M 466 223.15 C 464.05 238.25 457.67 245.92 442.15 247 M 442.15 247 C 378.85 245.62 317.23 244.85 209.85 247 M 442.15 247 C 372.04 247.58 301.59 248.54 209.85 247 M 209.85 247 C 192.92 247.13 187.84 238.28 186 223.15 M 209.85 247 C 193.93 248.24 185.11 238.12 186 223.15 M 186 223.15 C 186.27 185.32 187.65 151.47 186 111.85 M 186 223.15 C 185.85 185.11 185.3 148.06 186 111.85 M 186 111.85 C 184.14 97.76 192.81 88.2 209.85 88 M 186 111.85 C 185.48 96.01 192.94 86.5 209.85 88" fill="none" stroke="rgb(0, 0, 0)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="186" y="99" width="280" height="148" rx="22.2" ry="22.2" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 206.21 100.55 L 444.63 100.44 L 455.4 100.22 L 461.09 106.3 L 465.86 120.92 L 465.78 225.39 L 461.9 240.27 L 456.24 242.74 L 442.99 246.82 L 210.2 246.53 L 196.65 245.83 L 187.48 239.53 L 186.95 225.27 L 184.64 117.01 L 188.77 108.7 L 193.77 102.76 L 209.78 99.8" fill="rgb(255, 255, 255)" stroke="none" pointer-events="all"/>
+        <path d="M 208.2 99 M 208.2 99 C 265.81 98.11 326.48 99.64 443.8 99 M 208.2 99 C 283.63 97.23 359.67 98.48 443.8 99 M 443.8 99 C 457.31 98.46 466.36 106.03 466 121.2 M 443.8 99 C 458.99 99.87 465.21 105.23 466 121.2 M 466 121.2 C 465.96 162.3 463.98 200.81 466 224.8 M 466 121.2 C 465.37 146.65 466.99 171.34 466 224.8 M 466 224.8 C 467.2 237.72 458.8 248.8 443.8 247 M 466 224.8 C 464.37 239.53 456.65 246.2 443.8 247 M 443.8 247 C 378.5 244.91 308.68 246.57 208.2 247 M 443.8 247 C 394.58 247.54 347.01 246.51 208.2 247 M 208.2 247 C 193.95 247.96 184.97 239.73 186 224.8 M 208.2 247 C 195.52 246.12 185.98 240.84 186 224.8 M 186 224.8 C 185.18 199.39 186 168.71 186 121.2 M 186 224.8 C 186.68 188.74 186.61 151.88 186 121.2 M 186 121.2 C 186.13 104.98 191.54 100.81 208.2 99 M 186 121.2 C 184.69 106.63 192.88 99.06 208.2 99" fill="none" stroke="rgb(0, 0, 0)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 278px; height: 1px; padding-top: 95px; margin-left: 187px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 278px; height: 1px; padding-top: 106px; margin-left: 187px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
@@ -50,16 +50,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="326" y="107" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                <text x="326" y="118" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
                     Gateway VM...
                 </text>
             </switch>
         </g>
-        <rect x="541" y="88" width="252" height="313" rx="37.8" ry="37.8" fill="#f8cecc" stroke="#b85450" stroke-dasharray="3 3" pointer-events="all"/>
+        <rect x="541" y="75" width="252" height="313" rx="37.8" ry="37.8" fill="#f8cecc" stroke="#b85450" stroke-dasharray="3 3" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 250px; height: 1px; padding-top: 95px; margin-left: 542px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 250px; height: 1px; padding-top: 82px; margin-left: 542px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <b>
@@ -71,7 +71,7 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="667" y="107" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                <text x="667" y="94" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
                     Honeypot Subnet...
                 </text>
             </switch>
@@ -96,7 +96,7 @@
             </g>
         </a>
         <rect x="183" y="288" width="283" height="189" rx="28.35" ry="28.35" fill="none" stroke="none" pointer-events="all"/>
-        <path d="M 209.58 286.53 L 437.09 286.88 L 450.68 290.79 L 455.75 292.87 L 459.6 293.29 L 462.84 302.35 L 464.88 314.83 L 465.75 449.52 L 467.19 454.61 L 461.16 466.7 L 456.23 472.26 L 449.67 476.92 L 437.85 478.86 L 211.28 475.23 L 197.5 475.04 L 192.87 473.1 L 185.52 464.75 L 183.63 461.06 L 183.25 450.32 L 182.13 311.51 L 188.74 299.28 L 194.87 292.34 L 197.97 289.09 L 211 289.59" fill="rgb(255, 255, 255)" stroke="none" pointer-events="all"/>
+        <path d="M 209.58 286.53 L 437.09 286.88 L 450.68 290.79 L 455.75 292.87 L 462.7 297.28 L 462.84 302.35 L 464.88 314.83 L 465.75 449.52 L 465.86 460.37 L 461.16 466.7 L 456.23 472.26 L 449.67 476.92 L 437.85 478.86 L 211.28 475.23 L 197.5 475.04 L 192.87 473.1 L 185.52 464.75 L 183.63 461.06 L 183.25 450.32 L 182.13 311.51 L 188.74 299.28 L 194.87 292.34 L 197.97 289.09 L 211 289.59" fill="rgb(255, 255, 255)" stroke="none" pointer-events="all"/>
         <path d="M 211.35 288 M 211.35 288 C 300.55 285.15 392.51 287.34 437.65 288 M 211.35 288 C 270.04 286.32 329.08 287.27 437.65 288 M 437.65 288 C 457.92 287.31 467.09 299.18 466 316.35 M 437.65 288 C 454.88 285.95 467.36 296.15 466 316.35 M 466 316.35 C 466.51 369.91 465.08 419.3 466 448.65 M 466 316.35 C 465.78 360.34 465.68 403.85 466 448.65 M 466 448.65 C 467.3 469.07 456.7 478.43 437.65 477 M 466 448.65 C 467.4 466.05 455.68 476.89 437.65 477 M 437.65 477 C 370.7 475.29 304.09 475.84 211.35 477 M 437.65 477 C 357.92 476.34 279.74 476.75 211.35 477 M 211.35 477 C 193.34 475.61 181.14 469.3 183 448.65 M 211.35 477 C 190.55 478.38 181.54 466.28 183 448.65 M 183 448.65 C 181.63 405.54 182.98 360.99 183 316.35 M 183 448.65 C 181.35 395.49 181.17 342.77 183 316.35 M 183 316.35 C 181.94 298.83 193.23 287.87 211.35 288 M 183 316.35 C 184.13 298.5 190.52 288.76 211.35 288" fill="none" stroke="rgb(0, 0, 0)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -122,8 +122,8 @@
                 </text>
             </switch>
         </g>
-        <path d="M 411.5 370 L 411.5 380 Q 411.5 390 411.5 388.82 L 411.5 387.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 411.5 392.88 L 408 385.88 L 411.5 387.63 L 415 385.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 399 370 L 399 396 Q 399 406 399.11 408.32 L 399.21 410.64" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 399.45 415.88 L 395.63 409.05 L 399.21 410.64 L 402.63 408.73 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="349" y="309" width="100" height="61" rx="9.15" ry="9.15" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -132,7 +132,7 @@
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
-                                    Prometheus:
+                                    Prometheus
                                 </div>
                                 <div align="center">
                                     <i>
@@ -146,7 +146,7 @@
                     </div>
                 </foreignObject>
                 <text x="399" y="343" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    Prometheus:...
+                    Prometheus...
                 </text>
             </switch>
         </g>
@@ -190,7 +190,7 @@
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 260px; margin-left: 398px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 259px; margin-left: 398px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; background-color: rgb(255, 255, 255); white-space: nowrap;">
                                 <div>
@@ -240,12 +240,12 @@
                 </text>
             </switch>
         </g>
-        <path d="M 257.88 177.3 L 221 177.3 Q 211 177.3 211 187.3 L 211 274 Q 211 284 211.9 284 L 212.35 284 Q 212.8 284 212.8 294 L 212.75 405.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 212.75 410.88 L 209.25 403.88 L 212.75 405.63 L 216.25 403.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 257.88 177 L 221 177 Q 211 177 211 187 L 211 274 Q 211 284 211.92 284 L 212.38 284 Q 212.83 284 212.83 294 L 212.75 405.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 212.75 410.88 L 209.26 403.88 L 212.75 405.63 L 216.26 403.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 281px; margin-left: 211px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 280px; margin-left: 211px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
                                 <span style="background-color: rgb(213 , 232 , 212)">
@@ -262,23 +262,26 @@
                 </text>
             </switch>
         </g>
-        <rect x="257.88" y="162" width="127.75" height="30.5" rx="4.58" ry="4.58" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <rect x="257.88" y="147" width="127.75" height="45.5" rx="6.83" ry="6.83" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 126px; height: 1px; padding-top: 177px; margin-left: 259px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 126px; height: 1px; padding-top: 170px; margin-left: 259px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
-                                <div>
-                                    ContainerSSH
-                                    <br/>
-                                </div>
+                                ContainerSSH gateway
+                                <br/>
+                                <span style="font-weight: normal">
+                                    <i>
+                                        :22
+                                    </i>
+                                </span>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="322" y="181" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    ContainerSSH
+                <text x="322" y="173" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    ContainerSSH gateway...
                 </text>
             </switch>
         </g>
@@ -315,35 +318,6 @@
                 </text>
             </switch>
         </g>
-        <rect x="386.63" y="499" width="50" height="36" fill="none" stroke="none" pointer-events="all"/>
-        <path d="M 388.13 535 C 387.24 534.82 386.63 533.99 386.73 533.09 L 386.73 500.66 C 386.75 499.85 387.33 499.16 388.13 499 L 435.13 499 C 435.93 499.16 436.51 499.85 436.53 500.66 L 436.53 533.09 C 436.63 533.99 436.02 534.82 435.13 535 Z M 391.03 530.68 L 432.28 530.68 L 432.28 503.37 L 391.03 503.37 Z M 392.73 519.06 L 392.73 516.9 L 394.28 516.9 L 397.03 511.22 L 401.73 516.35 L 407.03 505.74 L 415.58 524.09 L 425.53 509.61 L 429.23 521.27 L 430.58 521.27 L 430.58 523.44 L 427.63 523.44 L 424.83 514.34 L 415.28 528.31 L 406.98 510.61 L 402.33 520.12 L 397.53 514.89 L 395.53 519.01 Z" fill="#00188d" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 542px; margin-left: 412px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
-                                <div>
-                                    <b>
-                                        Monitor
-                                        <br/>
-                                    </b>
-                                </div>
-                                <div>
-                                    <i>
-                                        &lt;logger-vm&gt;:3000
-                                    </i>
-                                    <br/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="412" y="554" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Monitor...
-                </text>
-            </switch>
-        </g>
         <path d="M 285.75 377 L 325.75 377 L 325.75 417 L 285.75 417 Z" fill="#ffffff" stroke="none" pointer-events="all"/>
         <path d="M 303.13 402.63 L 298.1 402.63 C 297.69 402.63 297.37 402.96 297.37 403.36 L 297.37 408.45 C 297.37 408.86 297.69 409.18 298.1 409.18 L 303.13 409.18 C 303.53 409.18 303.86 408.86 303.86 408.45 L 303.86 403.36 C 303.86 402.96 303.53 402.63 303.13 402.63 Z M 298.83 407.72 L 298.83 404.09 L 302.4 404.09 L 302.4 407.72 Z M 309.8 406.67 C 311.78 406.67 313.39 405.05 313.39 403.06 C 313.39 401.07 311.78 399.45 309.8 399.45 C 307.82 399.45 306.21 401.07 306.21 403.06 C 306.21 405.05 307.82 406.67 309.8 406.67 Z M 309.8 400.91 C 310.98 400.91 311.93 401.88 311.93 403.06 C 311.93 404.25 310.98 405.21 309.8 405.21 C 308.62 405.21 307.67 404.25 307.67 403.06 C 307.67 401.88 308.62 400.91 309.8 400.91 Z M 303.12 399.9 C 303.25 399.68 303.24 399.39 303.11 399.17 L 299.93 393.87 C 299.66 393.43 298.94 393.43 298.68 393.87 L 295.5 399.17 C 295.36 399.4 295.36 399.68 295.49 399.9 C 295.62 400.13 295.86 400.27 296.12 400.27 L 302.48 400.27 C 302.75 400.27 302.99 400.13 303.12 399.9 Z M 297.41 398.82 L 299.3 395.66 L 301.2 398.82 Z M 321.06 398.62 C 320.9 397.78 319.94 396.9 317.98 395.78 L 319.23 386.52 L 319.23 386.52 L 319.23 386.52 L 319.27 386.23 C 319.27 386.2 319.27 386.17 319.27 386.14 C 319.27 383.11 311.66 381 304.82 381 C 297.99 381 290.37 383.11 290.37 386.14 C 290.37 386.17 290.37 386.2 290.38 386.23 L 290.41 386.52 L 290.41 386.52 L 290.41 386.52 L 293.48 409.33 C 293.58 412 300.47 413 304.82 413 C 307.23 413 309.64 412.75 311.62 412.29 C 312.41 412.11 313.12 411.89 313.74 411.65 C 315.31 411.03 316.13 410.25 316.16 409.33 L 317.42 399.95 C 318.11 400.09 318.74 400.18 319.26 400.18 C 319.96 400.18 320.49 400.03 320.78 399.69 C 321.03 399.39 321.13 399.01 321.06 398.62 Z M 304.82 382.46 C 312.38 382.46 317.71 384.8 317.81 386.1 L 317.79 386.25 C 317.78 386.3 317.75 386.34 317.73 386.39 C 317.71 386.43 317.69 386.46 317.67 386.5 C 317.63 386.55 317.59 386.59 317.54 386.64 C 317.51 386.68 317.48 386.72 317.44 386.76 C 317.38 386.8 317.32 386.85 317.26 386.9 C 317.2 386.94 317.16 386.98 317.1 387.02 C 317.03 387.07 316.95 387.11 316.87 387.16 C 316.8 387.2 316.74 387.24 316.66 387.28 C 316.58 387.33 316.48 387.37 316.38 387.42 C 316.3 387.46 316.22 387.5 316.13 387.54 C 316.03 387.59 315.91 387.63 315.8 387.68 C 315.7 387.72 315.61 387.76 315.5 387.8 C 315.38 387.84 315.25 387.88 315.13 387.93 C 315.01 387.97 314.9 388.01 314.78 388.05 C 314.65 388.09 314.51 388.13 314.37 388.17 C 314.24 388.21 314.11 388.24 313.98 388.28 C 313.83 388.32 313.68 388.36 313.53 388.39 C 313.38 388.43 313.24 388.47 313.09 388.5 C 312.93 388.54 312.76 388.57 312.6 388.6 C 312.44 388.64 312.29 388.67 312.12 388.7 C 311.95 388.74 311.76 388.77 311.58 388.8 C 311.41 388.83 311.25 388.86 311.08 388.88 C 310.88 388.91 310.68 388.94 310.48 388.97 C 310.31 388.99 310.14 389.02 309.96 389.04 C 309.75 389.06 309.53 389.08 309.31 389.11 C 309.13 389.13 308.96 389.15 308.77 389.16 C 308.53 389.19 308.29 389.2 308.04 389.22 C 307.87 389.23 307.7 389.25 307.52 389.26 C 307.24 389.28 306.95 389.29 306.66 389.3 C 306.51 389.3 306.36 389.31 306.2 389.32 C 305.75 389.33 305.29 389.34 304.82 389.34 C 304.35 389.34 303.89 389.33 303.44 389.32 C 303.29 389.31 303.14 389.3 302.99 389.3 C 302.7 389.29 302.4 389.28 302.12 389.26 C 301.95 389.25 301.79 389.23 301.62 389.22 C 301.37 389.2 301.11 389.19 300.87 389.16 C 300.69 389.15 300.53 389.13 300.35 389.11 C 300.13 389.09 299.9 389.06 299.68 389.04 C 299.51 389.02 299.36 388.99 299.19 388.97 C 298.98 388.94 298.76 388.91 298.56 388.88 C 298.4 388.86 298.25 388.83 298.1 388.8 C 297.9 388.77 297.7 388.74 297.52 388.7 C 297.36 388.67 297.22 388.64 297.07 388.61 C 296.89 388.57 296.71 388.54 296.55 388.5 C 296.41 388.47 296.27 388.43 296.14 388.4 C 295.98 388.36 295.81 388.32 295.66 388.28 C 295.53 388.25 295.41 388.21 295.29 388.17 C 295.14 388.13 294.99 388.09 294.86 388.05 C 294.74 388.01 294.63 387.97 294.52 387.93 C 294.4 387.89 294.26 387.84 294.14 387.8 C 294.04 387.76 293.95 387.72 293.85 387.68 C 293.74 387.63 293.62 387.59 293.51 387.54 C 293.42 387.5 293.35 387.46 293.26 387.42 C 293.17 387.38 293.07 387.33 292.98 387.28 C 292.91 387.24 292.84 387.2 292.78 387.16 C 292.7 387.11 292.61 387.07 292.54 387.02 C 292.48 386.98 292.44 386.94 292.39 386.9 C 292.33 386.85 292.26 386.8 292.21 386.76 C 292.16 386.72 292.13 386.68 292.1 386.64 C 292.05 386.59 292.01 386.55 291.97 386.5 C 291.95 386.46 291.93 386.43 291.91 386.39 C 291.89 386.34 291.86 386.3 291.85 386.25 L 291.83 386.1 C 291.93 384.8 297.26 382.46 304.82 382.46 Z M 314.71 409.18 C 314.7 409.21 314.7 409.24 314.7 409.27 C 314.7 409.39 314.42 409.81 313.2 410.29 C 312.66 410.51 312.01 410.7 311.29 410.87 C 309.42 411.3 307.12 411.54 304.82 411.54 C 298.67 411.54 294.94 409.97 294.94 409.27 C 294.94 409.24 294.94 409.21 294.94 409.18 L 292.15 388.48 C 292.33 388.58 292.52 388.68 292.72 388.78 C 292.77 388.8 292.83 388.83 292.88 388.85 C 293.06 388.93 293.25 389.01 293.44 389.09 C 293.52 389.12 293.6 389.15 293.68 389.19 C 293.89 389.26 294.1 389.34 294.32 389.41 C 294.38 389.43 294.43 389.45 294.49 389.47 C 294.77 389.55 295.06 389.64 295.36 389.72 C 295.43 389.74 295.51 389.75 295.59 389.77 C 295.82 389.83 296.06 389.89 296.3 389.94 C 296.4 389.97 296.5 389.99 296.6 390.01 C 296.87 390.07 297.14 390.12 297.42 390.17 C 297.48 390.18 297.53 390.19 297.59 390.2 C 297.92 390.26 298.27 390.31 298.61 390.37 C 298.71 390.38 298.8 390.39 298.9 390.4 C 299.16 390.44 299.43 390.47 299.7 390.51 C 299.81 390.52 299.92 390.53 300.02 390.54 C 300.35 390.58 300.68 390.61 301.01 390.64 C 301.04 390.64 301.08 390.64 301.12 390.65 C 301.49 390.68 301.86 390.7 302.23 390.72 C 302.33 390.73 302.43 390.73 302.54 390.74 C 302.82 390.75 303.1 390.76 303.38 390.77 C 303.49 390.78 303.6 390.78 303.71 390.78 C 304.08 390.79 304.45 390.8 304.82 390.8 C 305.19 390.8 305.56 390.79 305.93 390.78 C 306.04 390.78 306.15 390.78 306.26 390.77 C 306.54 390.76 306.82 390.75 307.1 390.74 C 307.21 390.73 307.31 390.73 307.41 390.72 C 307.78 390.7 308.15 390.68 308.52 390.65 C 308.56 390.64 308.59 390.64 308.63 390.64 C 308.96 390.61 309.29 390.58 309.62 390.54 C 309.72 390.53 309.83 390.52 309.93 390.51 C 310.21 390.47 310.48 390.44 310.75 390.4 C 310.84 390.39 310.93 390.38 311.03 390.37 C 311.37 390.31 311.72 390.26 312.05 390.2 C 312.11 390.19 312.16 390.18 312.21 390.17 C 312.49 390.12 312.77 390.07 313.05 390.01 C 313.14 389.99 313.24 389.97 313.33 389.95 C 313.58 389.89 313.82 389.83 314.06 389.77 C 314.13 389.75 314.21 389.74 314.28 389.72 C 314.58 389.64 314.87 389.55 315.15 389.47 C 315.21 389.45 315.26 389.43 315.32 389.41 C 315.54 389.34 315.75 389.26 315.96 389.18 C 316.04 389.15 316.12 389.12 316.19 389.09 C 316.39 389.02 316.58 388.93 316.77 388.85 C 316.82 388.82 316.87 388.8 316.92 388.78 C 317.12 388.68 317.31 388.58 317.49 388.48 L 316.19 398.13 C 313.55 397.28 309.85 395.75 306.34 394.08 C 306.3 393.27 305.64 392.63 304.82 392.63 C 303.98 392.63 303.3 393.31 303.3 394.15 C 303.3 395 303.98 395.68 304.82 395.68 C 305.15 395.68 305.45 395.57 305.7 395.39 C 308.85 396.9 312.86 398.68 316 399.59 Z M 304.75 394.15 C 304.75 394.12 304.78 394.09 304.82 394.09 C 304.83 394.09 304.84 394.1 304.85 394.1 L 304.8 394.2 C 304.77 394.2 304.75 394.18 304.75 394.15 Z M 317.61 398.55 L 317.77 397.34 C 319.06 398.13 319.46 398.58 319.57 398.77 C 319.23 398.88 318.54 398.78 317.61 398.55 Z" fill="#232f3e" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
@@ -369,13 +343,13 @@
             </switch>
         </g>
         <rect x="565.5" y="150" width="203" height="220" rx="30.45" ry="30.45" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <rect x="565.5" y="150" width="203" height="220" rx="30.45" ry="30.45" fill="none" stroke="none" pointer-events="all"/>
-        <path d="M 593.96 148.23 L 746.83 149.63 L 756.61 155.74 L 764.76 163.4 L 766.99 165.26 L 769.06 181.89 L 766.6 339.21 L 766.92 352.8 L 765.17 357.18 L 754.95 366.23 L 751.03 369.06 L 737.1 369.35 L 597.82 369.55 L 587.61 368.73 L 575.51 366.32 L 569.6 357.52 L 567.25 352.41 L 565.76 341.46 L 567.39 172.63 L 569.96 163.12 L 575.48 154.82 L 582.17 150.38 L 595.97 149.35" fill="rgb(255, 255, 255)" stroke="none" pointer-events="all"/>
-        <path d="M 595.95 150 M 595.95 150 C 641.65 151.2 684.56 150.08 738.05 150 M 595.95 150 C 641.93 150.91 686.96 151.48 738.05 150 M 738.05 150 C 759.76 149.79 768.62 158.88 768.5 180.45 M 738.05 150 C 758.2 148.79 766.32 160.69 768.5 180.45 M 768.5 180.45 C 769.29 242.1 769.5 300.41 768.5 339.55 M 768.5 180.45 C 767.48 237.27 768.51 294.57 768.5 339.55 M 768.5 339.55 C 767.72 359.3 757.58 368.52 738.05 370 M 768.5 339.55 C 769.84 359.86 757.4 369.99 738.05 370 M 738.05 370 C 705.51 371.57 669.31 369.57 595.95 370 M 738.05 370 C 698.16 368.3 656.27 368.16 595.95 370 M 595.95 370 C 573.98 368.33 565.01 360.49 565.5 339.55 M 595.95 370 C 573.92 368.19 564.12 357.69 565.5 339.55 M 565.5 339.55 C 567.72 298.18 564.9 253.59 565.5 180.45 M 565.5 339.55 C 567.79 287.55 567.83 234.95 565.5 180.45 M 565.5 180.45 C 564.16 160.21 577.12 151.07 595.95 150 M 565.5 180.45 C 563.77 157.87 577.18 149.95 595.95 150" fill="none" stroke="rgb(0, 0, 0)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="565.5" y="121" width="203" height="249" rx="30.45" ry="30.45" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 593.96 119.23 L 746.83 120.63 L 756.61 126.74 L 764.76 134.4 L 768.42 142.44 L 769.06 152.89 L 766.6 339.21 L 768.35 346.61 L 765.17 357.18 L 754.95 366.23 L 744.84 370.49 L 737.1 369.35 L 597.82 369.55 L 587.61 368.73 L 575.51 366.32 L 569.6 357.52 L 565.82 346.22 L 565.76 341.46 L 567.39 143.63 L 569.96 134.12 L 571.2 129.15 L 582.17 121.38 L 595.97 120.35" fill="rgb(255, 255, 255)" stroke="none" pointer-events="all"/>
+        <path d="M 595.95 121 M 595.95 121 C 641.65 122.2 684.56 121.08 738.05 121 M 595.95 121 C 641.93 121.91 686.96 122.48 738.05 121 M 738.05 121 C 759.76 120.79 768.62 129.88 768.5 151.45 M 738.05 121 C 758.2 119.79 766.32 131.69 768.5 151.45 M 768.5 151.45 C 769.32 224.13 769.53 293.47 768.5 339.55 M 768.5 151.45 C 767.46 218.59 768.49 286.22 768.5 339.55 M 768.5 339.55 C 767.72 359.3 757.58 368.52 738.05 370 M 768.5 339.55 C 769.84 359.86 757.4 369.99 738.05 370 M 738.05 370 C 705.51 371.57 669.31 369.57 595.95 370 M 738.05 370 C 698.16 368.3 656.27 368.16 595.95 370 M 595.95 370 C 573.98 368.33 565.01 360.49 565.5 339.55 M 595.95 370 C 573.92 368.19 564.12 357.69 565.5 339.55 M 565.5 339.55 C 567.88 290.37 565.07 237.97 565.5 151.45 M 565.5 339.55 C 568.05 277.98 568.09 215.81 565.5 151.45 M 565.5 151.45 C 564.16 131.21 577.12 122.07 595.95 121 M 565.5 151.45 C 563.77 128.87 577.18 120.95 595.95 121" fill="none" stroke="rgb(0, 0, 0)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 201px; height: 1px; padding-top: 157px; margin-left: 567px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 201px; height: 1px; padding-top: 128px; margin-left: 567px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <b>
@@ -391,64 +365,34 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="667" y="169" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="667" y="140" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Sacrificial VM...
                 </text>
             </switch>
         </g>
-        <rect x="579.5" y="191" width="140.54" height="64.17" rx="9.62" ry="9.62" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <rect x="592.25" y="168" width="149.5" height="110" rx="16.5" ry="16.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 139px; height: 1px; padding-top: 223px; margin-left: 580px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
-                                honeypot
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="650" y="227" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    honeypot
-                </text>
-            </switch>
-        </g>
-        <rect x="594.26" y="202" width="140.54" height="64.17" rx="9.62" ry="9.62" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 139px; height: 1px; padding-top: 234px; margin-left: 595px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
-                                honeypot
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="665" y="238" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    honeypot
-                </text>
-            </switch>
-        </g>
-        <rect x="606.5" y="213" width="140.54" height="64.17" rx="9.62" ry="9.62" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 139px; height: 1px; padding-top: 245px; margin-left: 607px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 175px; margin-left: 593px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
-                                    containerssh:
+                                    Docker daemon
                                 </div>
                                 <div>
-                                    guest-image
+                                    <span style="font-weight: normal">
+                                        <i>
+                                            :2376
+                                        </i>
+                                    </span>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="677" y="249" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    containerssh:...
+                <text x="667" y="187" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    Docker daemon...
                 </text>
             </switch>
         </g>
@@ -518,13 +462,71 @@
                 </text>
             </switch>
         </g>
-        <rect x="126" y="6" width="109" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="612" y="211" width="110" height="59" fill="none" stroke="none"/>
+        <rect x="612" y="211" width="90" height="39" rx="5.85" ry="5.85" fill="#f5f5f5" stroke="#666666"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 231px; margin-left: 613px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                honeypot
+                                <br/>
+                                containers
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="657" y="234" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    honeypot...
+                </text>
+            </switch>
+        </g>
+        <rect x="622" y="221" width="90" height="39" rx="5.85" ry="5.85" fill="#f5f5f5" stroke="#666666"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 241px; margin-left: 623px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                honeypot
+                                <br/>
+                                containers
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="667" y="244" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    honeypot...
+                </text>
+            </switch>
+        </g>
+        <rect x="632" y="231" width="90" height="39" rx="5.85" ry="5.85" fill="#f5f5f5" stroke="#666666"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 251px; margin-left: 633px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                honeypot
+                                <br/>
+                                containers
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="677" y="254" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    honeypot...
+                </text>
+            </switch>
+        </g>
+        <rect x="126" y="6" width="109" height="18" fill="none" stroke="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 15px; margin-left: 181px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; text-decoration: underline; white-space: nowrap;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-weight: bold; text-decoration: underline; white-space: nowrap;">
                                 Work in Progress
                             </div>
                         </div>
@@ -535,14 +537,14 @@
                 </text>
             </switch>
         </g>
-        <path d="M 305.75 237 L 305.79 263 Q 305.8 273 315.8 273 L 389 273 Q 399 273 399 283 L 399 302.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 399 307.88 L 395.5 300.88 L 399 302.63 L 402.5 300.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 305.75 237 L 305.81 263 Q 305.83 273 315.83 273 L 389 273 Q 399 273 399 283 L 399 302.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 399 307.88 L 395.5 300.88 L 399 302.63 L 402.5 300.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 259px; margin-left: 304px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); background-color: #D5E8D4; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; background-color: rgb(213, 232, 212); white-space: nowrap;">
+                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-style: italic; background-color: rgb(213, 232, 212); white-space: nowrap;">
                                 container's metrics
                             </div>
                         </div>
@@ -553,13 +555,13 @@
                 </text>
             </switch>
         </g>
-        <rect x="270" y="201" width="71.5" height="36" rx="5.4" ry="5.4" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <rect x="270" y="201" width="71.5" height="36" rx="5.4" ry="5.4" fill="#dae8fc" stroke="#6c8ebf"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 70px; height: 1px; padding-top: 219px; margin-left: 271px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
                                     <font style="font-size: 10px">
                                         cAdvisor
@@ -586,17 +588,15 @@
                 </text>
             </switch>
         </g>
-        <path d="M 411.5 434 L 411.5 456.5 Q 411.5 466.5 411.54 476.5 L 411.6 492.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 411.63 497.88 L 408.1 490.9 L 411.6 492.63 L 415.1 490.87 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="377.5" y="394" width="68" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <rect x="365.5" y="417" width="68" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 66px; height: 1px; padding-top: 414px; margin-left: 379px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 66px; height: 1px; padding-top: 437px; margin-left: 367px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
-                                    Grafana:
+                                    Grafana
                                 </div>
                                 <div>
                                     <i>
@@ -610,53 +610,20 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="412" y="418" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    Grafana:...
+                <text x="400" y="441" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    Grafana...
                 </text>
             </switch>
         </g>
-        <rect x="257.88" y="125.5" width="127.75" height="34" rx="5.1" ry="5.1" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 126px; height: 1px; padding-top: 143px; margin-left: 259px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
-                                <div>
-                                    <span style="font-weight: normal">
-                                        <b>
-                                            auth-config
-                                        </b>
-                                        <i>
-                                            <br/>
-                                        </i>
-                                    </span>
-                                </div>
-                                <div>
-                                    <span style="font-weight: normal">
-                                        <i>
-                                            :8080
-                                        </i>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="322" y="146" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    auth-config...
-                </text>
-            </switch>
-        </g>
-        <path d="M 315 315 L 325 315 Q 335 315 335 325 L 335 337.9 Q 335 347.9 338.97 347.89 L 342.93 347.88" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 348.18 347.86 L 341.19 351.38 L 342.93 347.88 L 341.17 344.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="226" y="300" width="89" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <path d="M 315 315 L 325 315 Q 335 315 335 325 L 335 337.92 Q 335 347.92 338.97 347.9 L 342.93 347.88" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 348.18 347.86 L 341.2 351.39 L 342.93 347.88 L 341.17 344.39 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <rect x="226" y="300" width="89" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 87px; height: 1px; padding-top: 315px; margin-left: 227px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
                                     <font style="font-size: 9px">
                                         node_exporter
@@ -683,15 +650,15 @@
                 </text>
             </switch>
         </g>
-        <path d="M 306.25 347.98 L 343.63 347.98" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 348.88 347.98 L 341.88 351.48 L 343.63 347.98 L 341.88 344.48 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="234.75" y="330" width="71.5" height="36" rx="5.4" ry="5.4" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <path d="M 306.25 347.98 L 343.63 347.98" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 348.88 347.98 L 341.88 351.48 L 343.63 347.98 L 341.88 344.48 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <rect x="234.75" y="330" width="71.5" height="36" rx="5.4" ry="5.4" fill="#dae8fc" stroke="#6c8ebf"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 70px; height: 1px; padding-top: 348px; margin-left: 236px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <div>
                                     <font style="font-size: 10px">
                                         cAdvisor
@@ -718,12 +685,50 @@
                 </text>
             </switch>
         </g>
-        <path d="M 603.01 302 L 513 302 Q 503 302 503 312 L 503 329.5 Q 503 339.5 493 339.5 L 455.37 339.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 450.12 339.5 L 457.12 336 L 455.37 339.5 L 457.12 343 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 594.26 339.5 L 523 339.5 Q 513 339.5 503 339.5 L 455.37 339.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 450.12 339.5 L 457.12 336 L 455.37 339.5 L 457.12 343 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 385.63 177.3 L 486.1 177.3 Q 496.1 177.3 496.1 187.3 L 496.1 235.1 Q 496.1 245.1 506.1 245.1 L 600.13 245.08" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 605.38 245.08 L 598.38 248.58 L 600.13 245.08 L 598.38 241.58 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 603.01 302 L 513 302 Q 503 302 503 312 L 503 329.5 Q 503 339.5 493 339.5 L 455.37 339.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 450.12 339.5 L 457.12 336 L 455.37 339.5 L 457.12 343 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 594.26 339.5 L 523 339.5 Q 513 339.5 503 339.5 L 455.37 339.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 450.12 339.5 L 457.12 336 L 455.37 339.5 L 457.12 343 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 385.63 169.75 L 478.92 169.75 Q 488.92 169.75 488.92 179.75 L 488.92 213 Q 488.92 223 498.92 223 L 585.88 223" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 591.13 223 L 584.13 226.5 L 585.88 223 L 584.13 219.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 196px; margin-left: 489px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: #D5E8D4; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(213, 232, 212); white-space: nowrap;">
+                                TLS
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="489" y="199" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="9px" text-anchor="middle">
+                    TLS
+                </text>
+            </switch>
+        </g>
+        <path d="M 345 532 L 345 523.5 Q 345 515 335 515 L 238.5 515 Q 228.5 515 228.5 505 L 228.5 463.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 228.5 458.12 L 232 465.12 L 228.5 463.37 L 225 465.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 345 532 L 345 524 Q 345 516 355 516 L 389.5 516 Q 399.5 516 399.5 506 L 399.5 463.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 399.5 458.12 L 403 465.12 L 399.5 463.37 L 396 465.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <rect x="320" y="532" width="50" height="36" fill="none" stroke="none"/>
+        <path d="M 322.01 557.91 C 320.9 557.91 320 557.02 320 555.92 L 320 534 C 320 532.89 320.9 532 322.01 532 L 358.19 532 C 359.3 532 360.2 532.89 360.2 534 L 360.2 542.39 C 359.36 542.17 358.5 542.11 357.64 542.19 L 357.64 534.5 L 322.51 534.5 L 322.51 555.32 L 351.36 555.32 C 349.87 555.88 348.62 556.78 347.74 557.91 L 344.62 557.91 C 344.31 558.81 344.18 559.76 344.22 560.71 C 344.49 561.66 345.34 562.33 346.33 562.36 C 346.16 563.32 346.04 564.28 345.98 565.25 L 329.35 565.25 C 328.76 565.09 328.36 564.56 328.36 563.96 C 328.36 563.35 328.76 562.82 329.35 562.66 C 330.71 562.72 332.07 562.67 333.42 562.51 C 334.15 562.41 334.85 562.12 335.43 561.66 C 335.87 561.21 336.07 560.58 335.98 559.96 C 335.93 559.26 335.77 558.57 335.53 557.91 Z M 358.29 555.87 C 355.3 555.78 352.91 553.05 352.91 549.73 C 352.96 546.44 355.33 543.77 358.29 543.68 C 359.78 543.62 361.22 544.23 362.3 545.37 C 363.38 546.5 364 548.07 364.02 549.73 C 364.02 551.39 363.41 552.99 362.33 554.15 C 361.25 555.31 359.79 555.93 358.29 555.87 Z M 347.39 568 C 347.59 565.67 347.91 563.36 348.34 561.06 C 348.55 559.62 349.37 558.35 350.6 557.56 L 352.91 556.17 C 353.33 556.08 353.77 556.17 354.12 556.42 C 355.24 557.56 356.87 558.24 358.6 558.27 C 360.34 558.3 362 557.68 363.17 556.57 C 363.63 556.3 364.21 556.3 364.67 556.57 L 367.34 558.16 C 367.95 558.72 368.42 559.43 368.69 560.21 C 369.28 562.78 369.71 565.38 370 568 Z" fill="#515151" stroke="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 575px; margin-left: 345px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Admin
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="345" y="587" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Admin
+                </text>
+            </switch>
+        </g>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -76,10 +76,13 @@ You should be able to log in with any password.
 
 ```bash
 # Gateway VM
-gcloud compute ssh gateway-vm --zone=europe-west3-c --ssh-flag="-p 2333"
+gcloud compute ssh root@gateway-vm --zone=europe-west3-c --ssh-flag="-p 2333"
 
-# Other VM
-gcp compute ssh <vm-name> --zone=europe-west3-c
+# Logger VM
+gcloud compute ssh root@logger-vm --zone=europe-west3-c
+
+# Sacrificial VM
+gcloud compute ssh root@sacrificial-vm --zone=europe-west3-c
 ```
 
 #### Managing MinIO with MinIO Client `mc`

--- a/terraform/firewall_rules.tf
+++ b/terraform/firewall_rules.tf
@@ -1,5 +1,6 @@
-# GCP has implied rules: allow all egress; deny all ingress
-# https://cloud.google.com/vpc/docs/firewalls#default_firewall_rules
+# Firewall rules naming convention:
+# "action_source_to_destination_service/port"
+
 locals {
   ports = {
     cadvisor      = "8088"

--- a/terraform/firewall_rules.tf
+++ b/terraform/firewall_rules.tf
@@ -1,7 +1,6 @@
 # GCP has implied rules: allow all egress; deny all ingress
 # https://cloud.google.com/vpc/docs/firewalls#default_firewall_rules
 locals {
-  internal_ip_ranges = ["10.128.0.0/9"]
   ports = {
     cadvisor      = "8088"
     node_exporter = "9100"
@@ -9,12 +8,12 @@ locals {
     minio_server  = "9000"
     minio_console = "9090"
     grafana       = "3000"
+    docker_tls    = "2376"
   }
 }
 
-## Network-wide rules
-resource "google_compute_firewall" "allow_icmp" {
-  name    = "allow-icmp"
+resource "google_compute_firewall" "allow_all_to_network_icmp" {
+  name    = "allow-all-to-network-icmp"
   network = google_compute_network.main.self_link
   allow {
     protocol = "icmp"
@@ -22,101 +21,91 @@ resource "google_compute_firewall" "allow_icmp" {
   source_ranges = ["0.0.0.0/0"]
 }
 
-resource "google_compute_firewall" "internal_allow_metrics" {
-  name    = "internal-allow-metrics"
+resource "google_compute_firewall" "allow_all_to_network_ssh" {
+  name    = "allow-all-to-network-ssh"
   network = google_compute_network.main.self_link
   allow {
     protocol = "tcp"
-    ports    = [local.ports.cadvisor, local.ports.node_exporter]
+    ports    = ["22"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "allow_all_to_gateway_vm_2333" {
+  name        = "allow-all-to-gateway-vm-2333"
+  description = "Allow access to Gateway VM's SSH server on port 2333"
+  network     = google_compute_network.main.self_link
+  allow {
+    protocol = "tcp"
+    ports    = ["2333"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gateway"]
+}
+
+resource "google_compute_firewall" "allow_all_to_logger_vm_grafana" {
+  name    = "allow-all-to-logger-vm-grafana"
+  network = google_compute_network.main.self_link
+  allow {
+    protocol = "tcp"
+    ports    = [local.ports.grafana]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["logger"]
+}
+
+resource "google_compute_firewall" "allow_all_to_logger_vm_minio" {
+  name    = "allow-all-to-logger-vm-minio"
+  network = google_compute_network.main.self_link
+  allow {
+    protocol = "tcp"
+    ports = [
+      local.ports.minio_console,
+      local.ports.minio_server
+    ]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["logger"]
+}
+
+resource "google_compute_firewall" "allow_all_to_logger_vm_prometheus" {
+  name    = "allow-all-to-logger-vm-prometheus"
+  network = google_compute_network.main.self_link
+  allow {
+    protocol = "tcp"
+    ports = [
+      local.ports.prometheus
+    ]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["logger"]
+}
+
+resource "google_compute_firewall" "allow_logger_vm_to_network_cadvisor" {
+  name    = "allow-logger-vm-to-network-cadvisor"
+  network = google_compute_network.main.self_link
+  allow {
+    protocol = "tcp"
+    ports    = [local.ports.cadvisor]
   }
   source_tags = ["logger"]
 }
 
-resource "google_compute_firewall" "internal_allow_node_exporter" {
-  name    = "allow-internal-cadvisor"
-  network = google_compute_network.main.self_link
-  allow {
-    protocol = "tcp"
-    ports    = ["8088"]
-  }
-  source_ranges = local.internal_ip_ranges
-}
-
-resource "google_compute_firewall" "internal_allow_ssh" {
-  name    = "internal-allow-ssh"
+resource "google_compute_firewall" "allow_logger_vm_to_network_node_exporter" {
+  name    = "allow-logger-vm-to-network-node-exporter"
   network = google_compute_network.main.self_link
 
   allow {
     protocol = "tcp"
-    ports    = ["22"]
-  }
-  source_ranges = local.internal_ip_ranges
-}
-
-  allow {
-    protocol = "tcp"
-    ports    = ["22"]
+    ports    = [local.ports.node_exporter]
   }
 
-  source_ranges = ["0.0.0.0/0"]
+  source_tags = ["logger"]
 }
 
-# open port 3000 for Grafana, 9000 and 9090 for MinIO on our logger-vm
-resource "google_compute_firewall" "firewall_logger_view" {
-  name    = "firewall-logger-view"
-  network = google_compute_network.main.self_link
-  allow {
-    protocol = "tcp"
-    ports    = ["3000", "9000", "9090"]
-  }
-  target_tags   = ["observer"]
-  source_ranges = ["0.0.0.0/0"]
-}
-
-# open gateway-port 9100 and 9101, to our prometheus and metrics server
-resource "google_compute_firewall" "firewall_gateway_nodeexport" {
-  name    = "firewall-gateway-nodeexport"
-  network = google_compute_network.main.self_link
-
-  allow {
-    protocol = "tcp"
-    ports    = ["8088", "9100", "9101"]
-  }
-
-  target_tags = ["gateway"]
-  source_tags = ["observer"]
-}
-
-# allow inbound connection on TCP port 2376 from gateway
-resource "google_compute_firewall" "firewall_sacrificial_exception" {
-  name        = "firewall-sacrificial-exception"
-  network     = google_compute_network.main.name
-  priority    = 500
-  source_tags = ["gateway"]
-  target_tags = ["sacrificial"]
-  allow {
-    protocol = "tcp"
-    ports    = ["2376"]
-  }
-}
-
-# open sacrificial-port 8088 for cadvisor and 9100 for node-exporter
-resource "google_compute_firewall" "firewall_sacrificial_nodeexport" {
-  name    = "firewall-sacrificial-nodeexport"
-  network = google_compute_network.main.self_link
-
-  allow {
-    protocol = "tcp"
-    ports    = ["8088", "9100"]
-  }
-
-  target_tags = ["sacrificial"]
-  source_tags = ["observer"]
-}
-
-# close all outgoing connection from sacrificial host
-resource "google_compute_firewall" "firewall_sacrificial_no_egress" {
-  name               = "firewall-sacrificial-no-egress"
+resource "google_compute_firewall" "deny_sacrificial_vm_to_all" {
+  name               = "deny-sacrificial-vm-to-all"
+  description        = "Deny all outgoing connection from sacrificial host"
   network            = google_compute_network.main.name
   direction          = "EGRESS"
   destination_ranges = ["0.0.0.0/0"]
@@ -124,4 +113,15 @@ resource "google_compute_firewall" "firewall_sacrificial_no_egress" {
   deny {
     protocol = "all"
   }
+}
+
+resource "google_compute_firewall" "allow_gateway_vm_to_sacrificial_vm_docker_tls" {
+  name    = "allow-gateway-vm-to-sacrificial-vm-docker-tls"
+  network = google_compute_network.main.name
+  allow {
+    protocol = "tcp"
+    ports    = [local.ports.docker_tls]
+  }
+  source_tags = ["gateway"]
+  target_tags = ["sacrificial"]
 }

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -62,7 +62,7 @@ resource "google_compute_instance" "sacrificial_vm" {
 resource "google_compute_instance" "logger_vm" {
   name         = "logger-vm"
   machine_type = var.machine_type
-  tags         = ["observer"]
+  tags         = ["logger"]
 
   boot_disk {
     initialize_params {


### PR DESCRIPTION
## Description
This PR will
- close #5 
- add firewall rule naming convention `action_source_to_destination_service/port`
- opened Prometheus to public for testing

## Testing the PR
> How do your team test if the PR is valid?
1. `terraform apply`
2. all monitor services should work. SSH to honeypot should work

## Takeaways
- GCP firewalls are stateful!
So we don't need to allow both ways for a connection.
   > When a connection is allowed through the firewall in either direction, return traffic matching this connection is also allowed. You cannot configure a firewall rule to deny associated response traffic.
   > https://cloud.google.com/vpc/docs/firewalls#specifications