### PR TITLE
Set up containerssh metrics server

### DIFF
--- a/terraform/files/config.yaml
+++ b/terraform/files/config.yaml
@@ -56,6 +56,10 @@ docker:
         /tmp: rw,noexec,nosuid,size=65536k,uid=1000,gid=1000
         /run: rw,noexec,nosuid,size=65536k,uid=1000,gid=1000
         /home/ubuntu: rw,noexec,nosuid,size=65536k,uid=1000,gid=1000
+metrics:
+  enable: true
+  listen: "0.0.0.0:9101"
+  path: "/metrics"
 audit:
   enable: true
   format: binary

--- a/terraform/files/prometheus.yml
+++ b/terraform/files/prometheus.yml
@@ -28,6 +28,10 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
+  - job_name: "containerssh-metrics"
+    static_configs:
+      - targets: ["gateway-vm:9101"]
+
   # expose node exporter metrics
   - job_name: "nodeexporter-gateway-vm"
     static_configs:

--- a/terraform/firewall_rules.tf
+++ b/terraform/firewall_rules.tf
@@ -107,7 +107,20 @@ resource "google_compute_firewall" "allow_logger_vm_to_network_node_exporter" {
     ports    = [local.ports.node_exporter]
   }
 
-  source_tags = ["logger"]
+  source_tags = [local.tags.logger_vm]
+}
+
+resource "google_compute_firewall" "allow_logger_vm_to_gateway_vm_containerssh_metrics" {
+  name    = "allow-logger-vm-to-gateway-vm-containerssh-metrics"
+  network = google_compute_network.main.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = [local.ports.containerssh_metrics]
+  }
+
+  source_tags = [local.tags.logger_vm]
+  target_tags = [local.tags.gateway_vm]
 }
 
 resource "google_compute_firewall" "deny_sacrificial_vm_to_all" {

--- a/terraform/firewall_rules.tf
+++ b/terraform/firewall_rules.tf
@@ -3,13 +3,19 @@
 
 locals {
   ports = {
-    cadvisor      = "8088"
-    node_exporter = "9100"
-    prometheus    = "9091"
-    minio_server  = "9000"
-    minio_console = "9090"
-    grafana       = "3000"
-    docker_tls    = "2376"
+    cadvisor             = "8088"
+    node_exporter        = "9100"
+    prometheus           = "9091"
+    minio_server         = "9000"
+    minio_console        = "9090"
+    grafana              = "3000"
+    docker_tls           = "2376"
+    containerssh_metrics = "9101"
+  }
+  tags = {
+    gateway_vm     = "gateway"
+    logger_vm      = "logger"
+    sacrificial_vm = "sacrificial"
   }
 }
 
@@ -41,7 +47,7 @@ resource "google_compute_firewall" "allow_all_to_gateway_vm_2333" {
     ports    = ["2333"]
   }
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["gateway"]
+  target_tags   = [local.tags.gateway_vm]
 }
 
 resource "google_compute_firewall" "allow_all_to_logger_vm_grafana" {
@@ -52,7 +58,7 @@ resource "google_compute_firewall" "allow_all_to_logger_vm_grafana" {
     ports    = [local.ports.grafana]
   }
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["logger"]
+  target_tags   = [local.tags.logger_vm]
 }
 
 resource "google_compute_firewall" "allow_all_to_logger_vm_minio" {
@@ -66,7 +72,7 @@ resource "google_compute_firewall" "allow_all_to_logger_vm_minio" {
     ]
   }
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["logger"]
+  target_tags   = [local.tags.logger_vm]
 }
 
 resource "google_compute_firewall" "allow_all_to_logger_vm_prometheus" {
@@ -79,7 +85,7 @@ resource "google_compute_firewall" "allow_all_to_logger_vm_prometheus" {
     ]
   }
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["logger"]
+  target_tags   = [local.tags.logger_vm]
 }
 
 resource "google_compute_firewall" "allow_logger_vm_to_network_cadvisor" {
@@ -89,7 +95,7 @@ resource "google_compute_firewall" "allow_logger_vm_to_network_cadvisor" {
     protocol = "tcp"
     ports    = [local.ports.cadvisor]
   }
-  source_tags = ["logger"]
+  source_tags = [local.tags.logger_vm]
 }
 
 resource "google_compute_firewall" "allow_logger_vm_to_network_node_exporter" {
@@ -110,7 +116,7 @@ resource "google_compute_firewall" "deny_sacrificial_vm_to_all" {
   network            = google_compute_network.main.name
   direction          = "EGRESS"
   destination_ranges = ["0.0.0.0/0"]
-  target_tags        = ["sacrificial"]
+  target_tags        = [local.tags.sacrificial_vm]
   deny {
     protocol = "all"
   }
@@ -123,6 +129,6 @@ resource "google_compute_firewall" "allow_gateway_vm_to_sacrificial_vm_docker_tl
     protocol = "tcp"
     ports    = [local.ports.docker_tls]
   }
-  source_tags = ["gateway"]
-  target_tags = ["sacrificial"]
+  source_tags = [local.tags.gateway_vm]
+  target_tags = [local.tags.sacrificial_vm]
 }

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -1,7 +1,7 @@
 resource "google_compute_instance" "gateway_vm" {
   name         = "gateway-vm"
   machine_type = var.machine_type
-  tags         = ["gateway"]
+  tags         = [local.tags.gateway_vm]
 
   boot_disk {
     initialize_params {
@@ -41,7 +41,7 @@ resource "google_compute_instance" "gateway_vm" {
 resource "google_compute_instance" "sacrificial_vm" {
   name         = "sacrificial-vm"
   machine_type = var.machine_type
-  tags         = ["sacrificial"]
+  tags         = [local.tags.sacrificial_vm]
   boot_disk {
     initialize_params {
       image = "sacrificial-vm-image"
@@ -62,7 +62,7 @@ resource "google_compute_instance" "sacrificial_vm" {
 resource "google_compute_instance" "logger_vm" {
   name         = "logger-vm"
   machine_type = var.machine_type
-  tags         = ["logger"]
+  tags         = [local.tags.logger_vm]
 
   boot_disk {
     initialize_params {


### PR DESCRIPTION
## Description
> What changes will the PR bring? Refer to relevant issues if applicable
> 
This PR will
- close #45 

Note:
The metrics server does not work with Prometheus yet.
It should be fixed in ContainerSSH version 0.5.
Added the issue tracker to #49 

## Testing the PR
Test if metrics server is running:
In terminal, run
```
gcloud compute ssh gateway-vm  --ssh-flag="-p 2333" --command="curl localhost:9101/metrics"
```
You should see something like
```
containerssh_ssh_current_connections{country="XX"} 0.000000
# HELP containerssh_ssh_handshake_successful Successful SSH handshakes since start
# UNIT containerssh_ssh_handshake_successful handshakes
# TYPE containerssh_ssh_handshake_successful counter
# HELP containerssh_ssh_handshake_failed Failed SSH handshakes since start
# UNIT containerssh_ssh_handshake_failed handshakes
# TYPE containerssh_ssh_handshake_failed counter
containerssh_ssh_handshake_failed{country="XX"} 6.000000
# EOF
-:--:-- 2285k
```
