### PR TITLE
fix: dockerd has too low nofile limit on sacrificial VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Gateway VM:
 - cAdvisor: `8088`
 - Node Exporter: `9100`
 - ContainerSSH auth-config server: `8080`
-- ContainerSSH metrics server(TBD): `9101`
+- ContainerSSH metrics server: `9101`
 
 Logger VM:
 

--- a/terraform/scripts/restart_dockerd_with_tls.sh
+++ b/terraform/scripts/restart_dockerd_with_tls.sh
@@ -4,13 +4,15 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Make docker daemon only accept connections with trusted certificate
 
-TARGET_DIR=/lib/systemd/system/local.conf
+TARGET_DIR=/lib/systemd/system/docker.service.d
 mkdir -p "$TARGET_DIR"
 
 # override default ExecStart
-cat > "$TARGET_DIR" << EOF
+cat > "$TARGET_DIR/local.conf" << EOF
 [Service]
-ExecStart= --tlsverify --tlscacert=/home/deployer/ca.pem \
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock \
+  --tlsverify --tlscacert=/home/deployer/ca.pem \
   --tlskey=/home/deployer/server-key.pem \
   --tlscert=/home/deployer/server-cert.pem \
   -H=0.0.0.0:2376

--- a/terraform/scripts/restart_dockerd_with_tls.sh
+++ b/terraform/scripts/restart_dockerd_with_tls.sh
@@ -3,14 +3,20 @@ set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 # Make docker daemon only accept connections with trusted certificate
-sudo systemctl stop docker.socket
-nohup sudo dockerd \
-   -H unix:///var/run/docker.sock \
-   --tlsverify \
-   --tlscacert=ca.pem \
-   --tlscert=server-cert.pem \
-   --tlskey=server-key.pem \
-   -H=0.0.0.0:2376 \
-   &> dockerd.log &
+
+TARGET_DIR=/lib/systemd/system/local.conf
+mkdir -p "$TARGET_DIR"
+
+# override default ExecStart
+cat > "$TARGET_DIR" << EOF
+[Service]
+ExecStart= --tlsverify --tlscacert=/home/deployer/ca.pem \
+  --tlskey=/home/deployer/server-key.pem \
+  --tlscert=/home/deployer/server-cert.pem \
+  -H=0.0.0.0:2376
+EOF
+
+systemctl daemon-reload
+systemctl restart docker
 
 sleep 1


### PR DESCRIPTION
## Description
> What changes will the PR bring? Refer to relevant issues if applicable
> 
This PR should
- fix #51 

## Testing the PR
> How do your team test if the PR is valid?
  1. `terraform apply`
  2. `gcloud compute ssh root@sacrificial-vm`, then `cat /proc/$(pidof dockerd)/limits | grep "Max open files"`. You should see both values larger than 65565.
  3. ssh into the honeypot 10 times at the same time. they should all work

## Takeaways
Written in the issue comments.
  